### PR TITLE
feat: #116 /ai/geneate-plan 응답 수정 및 챌린지 id로 Plan 조회 API 구현

### DIFF
--- a/journey/ai_manager/serializers.py
+++ b/journey/ai_manager/serializers.py
@@ -136,3 +136,24 @@ class TriggerWeeklyAnalysisSerializer(serializers.Serializer):
 
         return data
 
+
+class SimplePlanItemSerializer(serializers.ModelSerializer):
+    """Simple serializer for individual plan items."""
+    class Meta:
+        model = Plan
+        fields = ['id', 'plan_text']
+
+class GeneratePlanResponseSerializer(serializers.Serializer):
+    """Serializer for the generate plan API response."""
+    user = serializers.IntegerField(source='user.id')
+    challenge = serializers.IntegerField(source='challenge.id')
+    plans = SimplePlanItemSerializer(many=True)
+
+    def create(self, validated_data):
+        # This serializer is for response representation, not for creating objects.
+        raise NotImplementedError("This serializer is not meant for object creation.")
+
+    def update(self, instance, validated_data):
+        # This serializer is for response representation, not for updating objects.
+        raise NotImplementedError("This serializer is not meant for object update.")
+

--- a/journey/ai_manager/serializers.py
+++ b/journey/ai_manager/serializers.py
@@ -145,9 +145,24 @@ class SimplePlanItemSerializer(serializers.ModelSerializer):
 
 class GeneratePlanResponseSerializer(serializers.Serializer):
     """Serializer for the generate plan API response."""
-    user = serializers.IntegerField(source='user.id')
-    challenge = serializers.IntegerField(source='challenge.id')
-    plans = SimplePlanItemSerializer(many=True)
+    user = serializers.IntegerField() 
+    challenge = serializers.IntegerField()
+    plans = SimplePlanItemSerializer(many=True, read_only=True)
+
+    def to_representation(self, instance):
+        """
+        Override to_representation to handle both dictionary and object instances.
+        This makes the serializer more flexible to work with different input types.
+        """
+        if isinstance(instance, dict):
+            # If instance is a dict, format accordingly
+            return {
+                'user': instance.get('user'),
+                'challenge': instance.get('challenge'),
+                'plans': SimplePlanItemSerializer(instance.get('plans', []), many=True).data
+            }
+        # For other cases, use default behavior
+        return super().to_representation(instance)
 
     def create(self, validated_data):
         # This serializer is for response representation, not for creating objects.

--- a/journey/ai_manager/services/kpi_generator.py
+++ b/journey/ai_manager/services/kpi_generator.py
@@ -134,7 +134,7 @@ def generate_kpis_for_challenge(challenge: Challenge, plan_ids: List[int], user_
     if not plans_data:
         raise ValueError("유효한 계획 데이터가 없습니다. 적어도 하나의 계획이 필요합니다.")
     
-    template_str = (Path(__file__).parent.parent / "templates" / "kpi_generator_prompt.txt").read_text()
+    template_str = (Path(__file__).parent.parent / "templates" / "kpi_generator_prompt.txt").read_text(encoding="utf-8")
     prompt = PromptTemplate(
         input_variables=["challenge_name", "challenge_description", "plans", "user_context", "item_count"],
         template=template_str

--- a/journey/ai_manager/services/plan_generator.py
+++ b/journey/ai_manager/services/plan_generator.py
@@ -82,7 +82,7 @@ def generate_plan_from_retrospect(challenge, retrospect):
         })
     
     # 프롬프트 - JSON 형식 출력을 요청하도록 수정
-    template_str = (Path(__file__).parent.parent / "templates" / "plan_from_retrospect_prompt.txt").read_text()
+    template_str = (Path(__file__).parent.parent / "templates" / "plan_from_retrospect_prompt.txt").read_text(encoding="utf-8")
     prompt = PromptTemplate(
         input_variables=["challenge_name", "kpi_info", "retrospect_content"],
         template=template_str
@@ -150,7 +150,7 @@ def generate_plan_from_challenge(challenge, user_context="", item_count=3):
     item_count = max(1, min(item_count, 5))  # 1-5 사이의 값으로 제한
     
     # JSON 형식 프롬프트로 수정
-    template_str = (Path(__file__).parent.parent / "templates" / "plan_from_challenge_prompt.txt").read_text()
+    template_str = (Path(__file__).parent.parent / "templates" / "plan_from_challenge_prompt.txt").read_text(encoding="utf-8")
     prompt_template = PromptTemplate(
         input_variables=["challenge_name", "challenge_description", "user_context", "item_count"],
         template=template_str

--- a/journey/ai_manager/views.py
+++ b/journey/ai_manager/views.py
@@ -7,7 +7,7 @@ from django.db.models import Q
 import logging
 from .serializers import (
     GenerateKpiRequestSerializer, GeneratePlanRequestSerializer, KpiListResponseSerializer,
-    GenerateNextPlanSerializer, TriggerWeeklyAnalysisSerializer
+    GenerateNextPlanSerializer, TriggerWeeklyAnalysisSerializer, GeneratePlanResponseSerializer
 )
 from .permissions import IsAuthenticated
 from drf_yasg import openapi
@@ -161,8 +161,15 @@ class GeneratePlanFromChallengeAPIView(generics.GenericAPIView):
         responses={
             201: openapi.Response(
                 description="Plan successfully created",
-                schema=PlanResponseSerializer(many=True),
-                examples={'application/json': plan_list_example}
+                schema=GeneratePlanResponseSerializer,
+                examples={'application/json': {
+                    "user": 1,
+                    "challenge": 1,
+                    "plans": [
+                        {"id": 1, "content": "Complete Chapter 1 of 'Advanced Python'", "is_done": False},
+                        {"id": 2, "content": "Practice 5 LeetCode problems (Easy)", "is_done": False}
+                    ]
+                }},
             ),
             400: openapi.Response("Bad request, invalid input parameters"),
             403: openapi.Response("Permission Denied"),
@@ -206,7 +213,12 @@ class GeneratePlanFromChallengeAPIView(generics.GenericAPIView):
             generated_plans = generate_plan_from_challenge(challenge, user_context, item_count)
         
             # 새로운 직렬화 클래스로 응답 생성
-            response_serializer = PlanResponseSerializer(generated_plans)
+            response_data = {
+                "user": request.user,  # user 인스턴스 전달
+                "challenge": challenge,  # challenge 인스턴스 전달
+                "plans": generated_plans
+            }
+            response_serializer = GeneratePlanResponseSerializer(instance=response_data)
             return Response(response_serializer.data, status=status.HTTP_201_CREATED)
             
         except Challenge.DoesNotExist:

--- a/journey/ai_manager/views.py
+++ b/journey/ai_manager/views.py
@@ -166,8 +166,8 @@ class GeneratePlanFromChallengeAPIView(generics.GenericAPIView):
                     "user": 1,
                     "challenge": 1,
                     "plans": [
-                        {"id": 1, "content": "Complete Chapter 1 of 'Advanced Python'", "is_done": False},
-                        {"id": 2, "content": "Practice 5 LeetCode problems (Easy)", "is_done": False}
+                        {"id": 1, "plan_text": "Complete Chapter 1 of 'Advanced Python'"},
+                        {"id": 2, "plan_text": "Practice 5 LeetCode problems (Easy)"}
                     ]
                 }},
             ),
@@ -210,15 +210,15 @@ class GeneratePlanFromChallengeAPIView(generics.GenericAPIView):
                     )
             
             # Plan 생성
-            generated_plans = generate_plan_from_challenge(challenge, user_context, item_count)
-        
-            # 새로운 직렬화 클래스로 응답 생성
+            generated_plans = generate_plan_from_challenge(challenge, user_context, item_count)            # 새로운 직렬화 클래스로 응답 생성
             response_data = {
-                "user": request.user,  # user 인스턴스 전달
-                "challenge": challenge,  # challenge 인스턴스 전달
-                "plans": generated_plans
+                "user": request.user.id,
+                "challenge": challenge.id,
+                "plans": generated_plans  # Plan model instances
             }
-            response_serializer = GeneratePlanResponseSerializer(instance=response_data)
+            
+            # Use the improved serializer with the response data
+            response_serializer = GeneratePlanResponseSerializer(response_data)
             return Response(response_serializer.data, status=status.HTTP_201_CREATED)
             
         except Challenge.DoesNotExist:

--- a/journey/retrospect/views.py
+++ b/journey/retrospect/views.py
@@ -342,6 +342,34 @@ class PlanViewSet(viewsets.ModelViewSet):
         serializer = self.get_serializer(instance)
         return Response(serializer.data)
 
+    @action(detail=False, methods=['get'], url_path='by-challenge/(?P<challenge_id>[^/.]+)')
+    def by_challenge(self, request, challenge_id=None):
+        """
+        특정 챌린지의 Plan 목록을 조회합니다.
+        """
+        if not challenge_id:
+            return Response({"error": "challenge_id is required."}, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            challenge = Challenge.objects.get(pk=challenge_id)
+        except Challenge.DoesNotExist:
+            return Response({"error": f"Challenge with id {challenge_id} not found."}, status=status.HTTP_404_NOT_FOUND)
+        # 챌린지 소유자 또는 크루 멤버인지 확인
+        if challenge.owner_type == ChallengeOwnerType.USER:
+            if challenge.user != request.user:
+                raise PermissionDenied("오직 챌린지 소유자만 계획을 조회할 수 있습니다.")
+        elif challenge.owner_type == ChallengeOwnerType.CREW:
+            if not CrewMembership.objects.filter(
+                crew=challenge.crew,
+                user=request.user,
+                status=CrewMembershipStatus.ACCEPTED
+            ).exists():
+                raise PermissionDenied("오직 크루 멤버만 계획을 조회할 수 있습니다.")
+        
+        queryset = Plan.objects.filter(challenge=challenge, user=request.user)
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)
+        
 class KpiViewSet(viewsets.ModelViewSet):
     """
     KPI를 관리하는 ViewSet


### PR DESCRIPTION
## PR 타입
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update <!-- (formatting, local variables) -->
- [ ] Refactoring <!-- (no functional changes, no api changes) -->
- [ ] Other... Please describe:


## 작업 내용


관련 이슈: #116 
1. /ai/geneate-plan 응답 수정 
 - resposne에 plan id 보여줌
2. 챌린지 id로 Plan 조회 API 구현

## 테스트 결과
- /ai/generate-plan 결과 -> 응답 수정
![image](https://github.com/user-attachments/assets/e9c494b3-afd9-4b63-a2fc-a51b15340dd6)

- 챌린지 Id로 Plan 조회 API 결과
![image](https://github.com/user-attachments/assets/bbb5f89a-a073-4eb5-a883-a3bc1599a08a)



## PR 체크리스트
- [x] 커밋 메시지가 가이드라인을 따르는가
- [ ] 테스트 코드를 모두 통과하였는가
- [x] 관련 이슈를 연결하였는가
