### PR TITLE
#118 fix: kpi_generator LLM response 추출 수정

### DIFF
--- a/journey/ai_manager/services/kpi_generator.py
+++ b/journey/ai_manager/services/kpi_generator.py
@@ -159,10 +159,17 @@ def generate_kpis_for_challenge(challenge: Challenge, plan_ids: List[int], user_
     # LLM 체인 생성 및 실행
     chain = prompt | llm
     
-    try:
-        # LLM 호출 및 응답 처리
+    try:        # LLM 호출 및 응답 처리
         response = chain.invoke(input_data, config={"callbacks": callbacks})
-        response_text = response.get("text", str(response)).strip()
+        # 응답 객체가 AIMessage인 경우 .content 속성을 사용
+        if hasattr(response, 'content'):
+            response_text = str(response.content).strip()
+        # 응답이 dict 형태이고 "text" 키가 있는 경우
+        elif isinstance(response, dict) and "text" in response:
+            response_text = str(response["text"]).strip()
+        # 기타 경우
+        else:
+            response_text = str(response).strip()
         logger.info(f"KPI 생성을 위한 LLM 응답 수신: {len(response_text)} 자")
         
         if langfuse_handler:


### PR DESCRIPTION
The issue was that when using the prompt | llm chain construct, the LangChain response is an AIMessage object that doesn't have a .get() method. Instead, we need to access its content via the .content attribute

## PR 타입
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update <!-- (formatting, local variables) -->
- [ ] Refactoring <!-- (no functional changes, no api changes) -->
- [ ] Other... Please describe:


## 작업 내용
- kpi_generator LLM response 추출 수정
   - Langchain response has no attribute get() (ver. prompt | chain))

- error reason
  - The issue was that when using the [prompt | llm] chain construct, the LangChain response is an AIMessage object that doesn't have a .get() method. Instead, we need to access its content via the .content attribute

관련 이슈: #118


## 테스트 결과
<!-- 테스트 결과를 스크린 샷으로 첨부해주세요. -->
![image](https://github.com/user-attachments/assets/049aaf4f-3a01-4bf9-b714-3966efb84788)



## PR 체크리스트
- [x] 커밋 메시지가 가이드라인을 따르는가
- [x] 테스트 코드를 모두 통과하였는가
- [x] 관련 이슈를 연결하였는가
